### PR TITLE
Update name of dixie.edu

### DIFF
--- a/e/edu/dixie.edu.toml
+++ b/e/edu/dixie.edu.toml
@@ -1,3 +1,3 @@
-name = "Dixie College"
+name = "Dixie State University"
 sld = "dixie"
 tld = "edu"


### PR DESCRIPTION
Dixie College is now officially Dixie State University and has been for a few years. This PR updates the name of the university. The domain name is unchanged.
